### PR TITLE
panTo feature

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -1,11 +1,10 @@
-import { CustomOverlayMap, Map, MapMarker } from 'react-kakao-maps-sdk';
+import { Map } from 'react-kakao-maps-sdk';
 
 import { useState } from 'react';
 import { UserData } from 'shared/Type';
-import useMapLevel from 'hooks/use-map-level';
 import useMarker from 'hooks/use-marker';
-import { CustomMapMarker } from 'components/CustomMapMarker';
 import { SideBar } from 'components/SideBar';
+import { MarkerListComponent } from 'components/MarkerList/MarkerList';
 
 const data: UserData[] = [
   {
@@ -60,16 +59,6 @@ const data: UserData[] = [
 export const MapComponent: React.FC = () => {
   const [map, setMap] = useState<kakao.maps.Map | undefined>();
   const markers = useMarker(data, map);
-  const level = useMapLevel(map);
-
-  const panTo = (lat: number, lng: number) => {
-    if (map) {
-      const moveCoord = new kakao.maps.LatLng(lat, lng);
-
-      map.setLevel(3);
-      map.panTo(moveCoord);
-    }
-  };
 
   return (
     <>
@@ -85,23 +74,7 @@ export const MapComponent: React.FC = () => {
         onCreate={setMap}
         level={12}
       >
-        {markers.map((marker, i) =>
-          level > 3 ? (
-            <MapMarker
-              key={i}
-              position={marker.position}
-              onClick={() => panTo(marker.position.lat, marker.position.lng)}
-            />
-          ) : (
-            <CustomOverlayMap position={marker.position}>
-              <CustomMapMarker
-                companyName={marker.name}
-                companyUrl={marker.imageUrl}
-                imageUrl={marker.imageUrl}
-              />
-            </CustomOverlayMap>
-          ),
-        )}
+        <MarkerListComponent markers={markers} />
         <SideBar />
       </Map>
     </>

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -5,6 +5,7 @@ import { UserData } from 'shared/Type';
 import useMapLevel from 'hooks/use-map-level';
 import useMarker from 'hooks/use-marker';
 import { CustomMapMarker } from 'components/CustomMapMarker';
+import { SideBar } from 'components/SideBar';
 
 const data: UserData[] = [
   {
@@ -101,6 +102,7 @@ export const MapComponent: React.FC = () => {
             </CustomOverlayMap>
           ),
         )}
+        <SideBar />
       </Map>
     </>
   );

--- a/src/components/MarkerList/MarkerList.tsx
+++ b/src/components/MarkerList/MarkerList.tsx
@@ -1,0 +1,45 @@
+import { CustomMapMarker } from 'components/CustomMapMarker';
+import useMapLevel from 'hooks/use-map-level';
+import { CustomOverlayMap, MapMarker, useMap } from 'react-kakao-maps-sdk';
+
+interface MarkerListComponentProps {
+  markers: any[];
+}
+
+export const MarkerListComponent: React.FC<MarkerListComponentProps> = ({
+  markers,
+}) => {
+  const map = useMap();
+  const level = useMapLevel(map);
+
+  const panTo = (lat: number, lng: number) => {
+    if (map) {
+      const moveCoord = new kakao.maps.LatLng(lat, lng);
+
+      map.setLevel(3);
+      map.panTo(moveCoord);
+    }
+  };
+
+  return (
+    <>
+      {markers.map((marker, i) =>
+        level > 3 ? (
+          <MapMarker
+            key={i}
+            position={marker.position}
+            onClick={() => panTo(marker.position.lat, marker.position.lng)}
+          />
+        ) : (
+          <CustomOverlayMap position={marker.position}>
+            <CustomMapMarker
+              companyName={marker.name}
+              companyUrl={marker.imageUrl}
+              imageUrl={marker.imageUrl}
+            />
+          </CustomOverlayMap>
+        ),
+      )}
+    </>
+  );
+};

--- a/src/components/SideBar/SideBar.tsx
+++ b/src/components/SideBar/SideBar.tsx
@@ -5,6 +5,7 @@ import { SearchInput } from 'components/SearchInput';
 import { UserList } from 'components/UserList';
 import { Logo } from 'assets/Logo';
 import pallete from 'shared/Pallete';
+import { useMap } from 'react-kakao-maps-sdk';
 
 const SideBar = styled.div`
   position: fixed;

--- a/src/components/UserCard/UserCard.tsx
+++ b/src/components/UserCard/UserCard.tsx
@@ -1,10 +1,12 @@
 import styled from '@emotion/styled';
 import Image from 'next/image';
 import { useCallback } from 'react';
+import { useMap } from 'react-kakao-maps-sdk';
 
 import pallete from 'shared/Pallete';
 import { UserData as UserCardProps } from 'shared/Type';
 import { Button } from 'components/common/Button';
+import useCoord from 'hooks/use-coord';
 
 const UserCard = styled.div`
   width: 100%;
@@ -82,9 +84,21 @@ export const UserCardComponent: React.FC<UserCardProps> = ({
   location,
   devYear,
 }) => {
+  const map = useMap();
+  const { lat, lng } = useCoord(map, location);
+
   const subString = useCallback((str: string, n: number): string => {
     return str.length > n ? `${str.substring(0, n)}...` : str;
   }, []);
+
+  const panTo = (lat: number, lng: number) => {
+    if (map) {
+      const moveCoord = new kakao.maps.LatLng(lat, lng);
+
+      map.setLevel(3);
+      map.panTo(moveCoord);
+    }
+  };
 
   return (
     <UserCard>
@@ -115,8 +129,13 @@ export const UserCardComponent: React.FC<UserCardProps> = ({
         </IntroduceCard>
       )}
       <UserButtonWrapper>
-        <Button>회사 위치</Button>
-        <Button secondary>연결 신청</Button>
+        <Button
+          onClick={() => {
+            if (lat && lng) panTo(lat, lng);
+          }}
+        >
+          회사 위치
+        </Button>
       </UserButtonWrapper>
     </UserCard>
   );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,15 +1,9 @@
 import type { NextPage } from 'next';
 
 import { Map } from 'components/Map';
-import { SideBar } from 'components/SideBar';
 
 const Home: NextPage = () => {
-  return (
-    <>
-      <Map />
-      <SideBar />
-    </>
-  );
+  return <Map />;
 };
 
 export default Home;


### PR DESCRIPTION
## 기능 개요

`UserCard` 컴포넌트의 회사 위치 버튼을 클릭시에 해당하는 회사로 panTo (맵의 포커스 좌표 이동 및 level 3로 확대) 하는 기능을 구현하였다

## 변경 사항

#### SideBar 컴포넌트가 Map 컴포넌트 내부에 위치 시킴
  - panTo 를 하기 위해선 coord 값이 필요한데 이 값은 기존에 있던 `useCoord`를 이용하였다. `useCoord` 를 이용하기 위해선 `kakao.maps.Map` 객체가 필요한데 전역 상태로 관리하기에는 복잡도가 증가할 듯 하여, `react-kakao-maps-sdk` 에서 제공하는 `useMap` hooks를 사용하였다. `useMap` hooks는 [Map 객체 내부가 아니라면 Error를 발생](https://react-kakao-maps-sdk.jaeseokim.dev/docs/api/functions/useMap)시키기 때문에 SideBar 컴포넌트가 MapComponent에 내부에 위치시켰다.

---

#### MapComponent에서 MarkerListComponent를 분리 시킴
  - SideBar 컴포넌트가 MapComponent에 내부에 위치시켰더니 SideBar 컴포넌트가 보이지 않을 정도로 코드 가독성이 떨어져서 Map 컴포넌트에서 MarkerList 컴포넌트를 분리시켰다.