### PR TITLE
Fix panTo another marker

### DIFF
--- a/src/components/SideBar/SideBar.tsx
+++ b/src/components/SideBar/SideBar.tsx
@@ -1,11 +1,10 @@
 import { useState } from 'react';
 import styled from '@emotion/styled';
-import { SearchInput } from 'components/SearchInput';
 
+import { SearchInput } from 'components/SearchInput';
 import { UserList } from 'components/UserList';
 import { Logo } from 'assets/Logo';
 import pallete from 'shared/Pallete';
-import { useMap } from 'react-kakao-maps-sdk';
 
 const SideBar = styled.div`
   position: fixed;

--- a/src/hooks/use-coord.ts
+++ b/src/hooks/use-coord.ts
@@ -20,7 +20,7 @@ const useCoord = (map: kakao.maps.Map | undefined, location: string) => {
         });
       }
     });
-  }, [map]);
+  }, [location, map]);
 
   return {
     lat: coord?.lat,


### PR DESCRIPTION
## 기능 개요

검색을 한 후 UserList가 변경된 후 #5 회사 위치 버튼을 클릭하면 `UserCard` 가 명시하는 위치가 아닌 기존에 그 위치에 있던 `UserCard` 로 panTo 된다.

<img width="2048" alt="스크린샷 2022-05-26 오후 5 45 20" src="https://user-images.githubusercontent.com/60869316/170452959-034b5999-5663-4722-9ccc-df87a00f4c7f.png">

useCoord hooks의 useEffect 부분에서 deps에 location을 넣어주지 않아 location이 바뀌어도 coord는 그대로이기 때문에 발생한 이슈였다.