### PR TITLE
Feature/cluster

### DIFF
--- a/src/components/MarkerList/MarkerList.tsx
+++ b/src/components/MarkerList/MarkerList.tsx
@@ -1,6 +1,11 @@
 import { CustomMapMarker } from 'components/CustomMapMarker';
 import useMapLevel from 'hooks/use-map-level';
-import { CustomOverlayMap, MapMarker, useMap } from 'react-kakao-maps-sdk';
+import {
+  CustomOverlayMap,
+  MapMarker,
+  MarkerClusterer,
+  useMap,
+} from 'react-kakao-maps-sdk';
 
 interface MarkerListComponentProps {
   markers: any[];
@@ -22,7 +27,10 @@ export const MarkerListComponent: React.FC<MarkerListComponentProps> = ({
   };
 
   return (
-    <>
+    <MarkerClusterer
+      averageCenter={true} // 클러스터에 포함된 마커들의 평균 위치를 클러스터 마커 위치로 설정
+      minLevel={10} // 클러스터 할 최소 지도 레벨
+    >
       {markers.map((marker, i) =>
         level > 3 ? (
           <MapMarker
@@ -40,6 +48,6 @@ export const MarkerListComponent: React.FC<MarkerListComponentProps> = ({
           </CustomOverlayMap>
         ),
       )}
-    </>
+    </MarkerClusterer>
   );
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import type { NextPage } from 'next';
 import Head from 'next/head';
 import { Toaster } from 'react-hot-toast';
+import { SWRConfig } from 'swr';
 
 import { Map } from 'components/Map';
 
@@ -16,7 +17,13 @@ const Home: NextPage = () => {
           content="HiRecruit을 통해 보다 뛰어난 멘토를 찾고, 혁신적인 취업준비 경험을 느끼세요."
         />
       </Head>
-      <Map />
+      <SWRConfig
+        value={{
+          revalidateOnFocus: false,
+        }}
+      >
+        <Map />
+      </SWRConfig>
       <Toaster />
     </>
   );


### PR DESCRIPTION
## 작업 내용

마커 클러스터를 재구축하고 swr로 인하여 revalidateOnFocus 이벤트 발생시

<img width="440px" src='https://cdn.discordapp.com/attachments/899519556794609694/985171987657805834/2022-06-11_10.17.30.png' />
<img width="440px" src='https://cdn.discordapp.com/attachments/899519556794609694/985171986869280808/2022-06-11_10.17.38.png' />

위와 같이 데이터 중첩이 되어 배로 표현되게 되어서 swr의 `revalidateOnFocus` option을 전역적으로 비활성화 시켰다.