### PR TITLE
Feature/residualar marker

### DIFF
--- a/src/hooks/use-marker.ts
+++ b/src/hooks/use-marker.ts
@@ -9,6 +9,8 @@ const useMarker = (map: kakao.maps.Map | undefined) => {
     if (!(map && data)) return;
     const gc = new kakao.maps.services.Geocoder();
 
+    setMarkers([]);
+
     data.forEach(info => {
       gc.addressSearch(info.location, (result, status) => {
         if (status === kakao.maps.services.Status.OK) {
@@ -29,7 +31,7 @@ const useMarker = (map: kakao.maps.Map | undefined) => {
         }
       });
     });
-  }, [map]);
+  }, [map, data]);
 
   return markers;
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,6 @@
 import type { NextPage } from 'next';
 import Head from 'next/head';
 import { Toaster } from 'react-hot-toast';
-import { SWRConfig } from 'swr';
 
 import { Map } from 'components/Map';
 
@@ -17,15 +16,7 @@ const Home: NextPage = () => {
           content="HiRecruit을 통해 보다 뛰어난 멘토를 찾고, 혁신적인 취업준비 경험을 느끼세요."
         />
       </Head>
-      <SWRConfig
-        value={{
-          revalidateIfStale: false,
-          revalidateOnFocus: false,
-          revalidateOnReconnect: false,
-        }}
-      >
-        <Map />
-      </SWRConfig>
+      <Map />
       <Toaster />
     </>
   );


### PR DESCRIPTION
## 개요

기존 `useMarker` hook 내부의 로직은 data (companyListData) 가 바뀔때마다 setState의 `prevState` 를 이용하여 marker를 생성하기 때문에 데이터 중복 문제가 있었다.
그 때문에 swr의 자동 갱신 기능과 더불어 웹페이지에 포커스 될 때마다 필요없는 마커들이 렌더링되었다.

## 작업 내용

- `data.forEach` 로직에 들어가기전 setState를 초기화
- uswSWRconfig option clear