### PR TITLE
[HOTFIX] keep login state

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -5,7 +5,11 @@ import useMarker from 'hooks/use-marker';
 import { SideBar } from 'components/SideBar';
 import { MarkerList } from 'components/MarkerList';
 
-export const MapComponent: React.FC = () => {
+interface MapProps {
+  isSigned: boolean;
+}
+
+export const MapComponent: React.FC<MapProps> = ({ isSigned }) => {
   const [map, setMap] = useState<kakao.maps.Map | undefined>();
   const markers = useMarker(map);
 
@@ -24,7 +28,7 @@ export const MapComponent: React.FC = () => {
         level={12}
       >
         <MarkerList markers={markers} />
-        <SideBar />
+        <SideBar isSigned={isSigned} />
       </Map>
     </>
   );

--- a/src/components/SideBar/SideBar.tsx
+++ b/src/components/SideBar/SideBar.tsx
@@ -10,10 +10,13 @@ import { Logo } from 'assets/icons/Logo';
 import * as S from './SideBar.styles';
 import { handleAuth, handleLogout } from './container';
 
-export const SideBarComponent: React.FC = () => {
+interface SideBarProps {
+  isSigned: boolean;
+}
+
+export const SideBarComponent: React.FC<SideBarProps> = ({ isSigned }) => {
   const [searchState, setSearchState] = useState<string>('');
   const [modalVisible, setModalVisible] = useState<boolean>(false);
-  const [isSigned, setIsSigned] = useState<boolean>(false);
 
   const router = useRouter();
 
@@ -23,9 +26,9 @@ export const SideBarComponent: React.FC = () => {
     }
   }, [router.query.is_first]);
 
+  // TODO: 서버 레거시 코드에 대응하기 위한 코드 추후 삭제해야됨
   useEffect(() => {
     if (router.query.is_login) {
-      setIsSigned(true);
       router.replace(router.pathname);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,10 +1,24 @@
-import type { NextPage } from 'next';
+import type { GetServerSideProps, NextPage } from 'next';
 import Head from 'next/head';
 import { Toaster } from 'react-hot-toast';
 
 import { Map } from 'components/Map';
+import { useEffect, useState } from 'react';
 
-const Home: NextPage = () => {
+interface HomeProps {
+  session: string | undefined;
+}
+
+const Home: NextPage<HomeProps> = ({ session }) => {
+  const [isSigned, setIsSigned] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (session !== 'undefined') {
+      setIsSigned(true);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
     <>
       <Head>
@@ -16,10 +30,20 @@ const Home: NextPage = () => {
           content="HiRecruit을 통해 보다 뛰어난 멘토를 찾고, 혁신적인 취업준비 경험을 느끼세요."
         />
       </Head>
-      <Map />
+      <Map isSigned={isSigned} />
       <Toaster />
     </>
   );
+};
+
+export const getServerSideProps: GetServerSideProps = async ctx => {
+  const session = `${ctx.req.cookies.SESSION}`;
+
+  return {
+    props: {
+      session,
+    },
+  };
 };
 
 export default Home;


### PR DESCRIPTION
## 개요

서비스 운영중 새로고침시 세션 쿠키가 남아있음에도 불구하고, 로그아웃 버튼이 아닌 회원가입/로그인 버튼이 뜨는 오류가 발생했다.

## 작업 내용

`getServerSideProps` 를 이용하여 `ctx.req.cookies.SESSION` 을 가져와서 로그인 상태를 확인하는 로직을 추가시켰다.