### PR TITLE
Hotfix companyMarker image

### DIFF
--- a/src/components/CompanyForm/CompanyForm.styles.tsx
+++ b/src/components/CompanyForm/CompanyForm.styles.tsx
@@ -56,6 +56,10 @@ export const ProfileImage = styled.div`
   border-radius: 1.75rem;
   overflow: hidden;
   background-color: ${pallete.scheme.gray};
+  img {
+    max-width: 276px;
+    max-height: 64px;
+  }
 `;
 
 export const WarningText = styled.div`

--- a/src/components/CompanyForm/CompanyForm.tsx
+++ b/src/components/CompanyForm/CompanyForm.tsx
@@ -119,7 +119,6 @@ export const CompanyFormComponent: React.FC<CompanyFormProps> = ({
               <img
                 src={previewCompanyImgUri}
                 alt="회사 이미지"
-                height="100%"
                 onError={() => {
                   setIsPicture(false);
                 }}


### PR DESCRIPTION
## 개요

<img width="500" alt="스크린샷 2022-06-13 오후 6 21 39" src="https://user-images.githubusercontent.com/60869316/173322330-2c0f74c7-f0ba-40fa-b282-1f895a7b45c6.png">

회사 이미지가 클 경우 `companyMarker` 를 늘려버리는일이 발생했다.

## 작업 내용

img tag에 `max-width` , `max-height` 속성을 추가해주었다.