### PR TITLE
Feature/inspection site

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,8 @@ const nextConfig = {
   env: {
     mapApiKey: process.env.NEXT_PUBLIC_MAP_API_KEY,
     baseUrl: process.env.NEXT_PUBLIC_BASE_URL,
+    gssIdKey: process.env.NEXT_PUBLIC_GSS_ID_KEY,
+    gssApiKey: process.env.NEXT_PUBLIC_GSS_API_KEY,
   },
   images: {
     domains: ['github.com', 'avatars.githubusercontent.com'],

--- a/src/hooks/api/google-spread-sheets/use-site-state.ts
+++ b/src/hooks/api/google-spread-sheets/use-site-state.ts
@@ -1,0 +1,30 @@
+import useSWR from 'swr';
+
+import axios from 'axios';
+
+type SiteStateToken = 'INSPECTION' | 'NORMAL';
+
+interface SiteStateData {
+  range: string;
+  majorDimension: string;
+  values: [[string], [SiteStateToken], [string]];
+}
+
+interface UseSiteState {
+  data: SiteStateData;
+}
+
+const useSiteState = () => {
+  const url = `https://sheets.googleapis.com/v4/spreadsheets/${process.env.gssIdKey}/values/sheet1?key=${process.env.gssApiKey}`;
+  const { data, error } = useSWR<UseSiteState>(url, axios.get);
+
+  const siteData = data?.data?.values[1][0];
+
+  return {
+    data: siteData,
+    isLoading: !error && !data,
+    isError: error,
+  };
+};
+
+export default useSiteState;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,10 +1,29 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import type { AppProps } from 'next/app';
 import Script from 'next/script';
+import { useRouter } from 'next/router';
 
 import { GlobalStyle } from 'shared/GlobalStyle';
+import useSiteState from 'hooks/api/google-spread-sheets/use-site-state';
 
 function MyApp({ Component, pageProps }: AppProps) {
+  const router = useRouter();
+  const { data: siteState } = useSiteState();
+
+  useEffect(() => {
+    switch (siteState) {
+      case 'INSPECTION':
+        router.replace('/site-state/inspection');
+        break;
+      case 'NORMAL':
+        router.replace('/');
+        break;
+      default:
+        router.replace('/');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [siteState]);
+
   return (
     <>
       <Script

--- a/src/pages/_middleware.ts
+++ b/src/pages/_middleware.ts
@@ -1,8 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function middleware(req: NextRequest) {
-  const fetchUrl =
-    'https://sheets.googleapis.com/v4/spreadsheets/1z65xVk7tqcp90SUVvOwl-XHozbydF5w5hyVjMVnxIkw/values/sheet1?key=AIzaSyDnEY-kE_ZCwuyQezxSuw1UO1dMOOgPYJw';
+  const fetchUrl = `https://sheets.googleapis.com/v4/spreadsheets/${process.env.gssIdKey}/values/sheet1?key=${process.env.gssApiKey}`;
   const res = await fetch(fetchUrl);
   const data = await res.json();
   const siteState = data?.values[1][0];

--- a/src/pages/_middleware.ts
+++ b/src/pages/_middleware.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function middleware(req: NextRequest) {
+  const fetchUrl =
+    'https://sheets.googleapis.com/v4/spreadsheets/1z65xVk7tqcp90SUVvOwl-XHozbydF5w5hyVjMVnxIkw/values/sheet1?key=AIzaSyDnEY-kE_ZCwuyQezxSuw1UO1dMOOgPYJw';
+  const res = await fetch(fetchUrl);
+  const data = await res.json();
+  const siteState = data?.values[1][0];
+
+  const { pathname, origin } = req.nextUrl;
+
+  if (siteState === 'INSPECTION' && pathname !== '/site-state/inspection') {
+    return NextResponse.redirect(`${origin}/site-state/inspection`);
+  } else {
+    return NextResponse.next();
+  }
+}

--- a/src/pages/site-state/inspection.tsx
+++ b/src/pages/site-state/inspection.tsx
@@ -1,0 +1,33 @@
+import styled from '@emotion/styled';
+import { NextPage } from 'next';
+
+import { Logo } from 'assets/icons/Logo';
+
+const InspectionWrapper = styled.main`
+  height: 100vh;
+  display: grid;
+  place-items: center;
+  section {
+    height: fit-content;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  h1 {
+    font-size: 1rem;
+    font-weight: 500;
+  }
+`;
+
+const InspectionPage: NextPage = () => {
+  return (
+    <InspectionWrapper>
+      <section>
+        <Logo logoColor="black" />
+        <h1>&nbsp;&nbsp;| 서비스가 점검중이에요</h1>
+      </section>
+    </InspectionWrapper>
+  );
+};
+
+export default InspectionPage;


### PR DESCRIPTION
## 개요

여러면에서 서비스 점검페이지의 필요성을 느끼고 점검페이지를 만들었다. 점검페이지를 구글 스프레드 시트 점검 페이지 관리자가 값을 바꾸면 기존 사이트 이용자는 data refetching이 일어났을경우 site state가 'INSPECTION'일 경우 `/site-state/inspection`으로 리다이렉트된다.
 새로운 요청의 경우에는 nextjs middleware를 활용하여 vercel 서버단에서 점검 상태를 fetching하고 site state가 'INSPECTION'일 경우에만 `/site-state/inspection`으로 리다이렉트 시킨다.
 
 ## 작업 내용

- `use-site-state` hook을 개발
- cliend, server side state router action을 개발
- 점검 페이지를 퍼블리싱하였다.