### PR TITLE
Feature/post error handling

### DIFF
--- a/src/components/CompanyForm/CompanyForm.tsx
+++ b/src/components/CompanyForm/CompanyForm.tsx
@@ -5,6 +5,7 @@ import {
   useEffect,
   useState,
 } from 'react';
+import { AxiosError, AxiosResponse } from 'axios';
 import { css } from '@emotion/react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import toast from 'react-hot-toast';
@@ -60,14 +61,24 @@ export const CompanyFormComponent: React.FC<CompanyFormProps> = ({
 
     axiosClient
       .post(companyUrl.getAllCompany(), reqData)
-      .then(function (response) {
+      .then(function (response: AxiosResponse) {
         toast.success('회사 등록이 완료되었어요');
         setCompanyFormModalVisible(false);
         mutate(companyUrl.getAllCompany());
       })
-      .catch(function (error) {
+      .catch(function (error: AxiosError<{ message: string }>) {
         console.log(error);
-        toast.error('회사 등록에 실패했어요');
+        if (error.response) {
+          switch (error.response.status) {
+            case 400:
+              toast.error(error.response.data.message);
+              break;
+            default:
+              toast.error(
+                '알 수 없는 이유로 등록에 실패했어요\nhirecruit@gsm.hs.kr에 문의해주세요',
+              );
+          }
+        }
       });
   };
 

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -1,6 +1,6 @@
-import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import { AxiosError, AxiosResponse } from 'axios';
+import { Dispatch, SetStateAction, useState } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
-import { useSWRConfig } from 'swr';
 import toast from 'react-hot-toast';
 import { css } from '@emotion/react';
 
@@ -8,7 +8,6 @@ import { Modal } from 'components/common/Modal';
 import { CompanyForm } from 'components/CompanyForm';
 import { WorkerReqData } from 'types/worker.type';
 import axiosClient from 'libs/axios/axiosClient';
-import { workerUrl } from 'libs/api/apiUrlControllers';
 import useCompanyList from 'hooks/api/company/use-company-list';
 
 import * as S from './Form.styles';
@@ -24,7 +23,6 @@ export const FormComponent: React.FC<SignUpFormProps> = ({
   const { register, handleSubmit } = useForm<InputListType>();
   const [companyFormModalVisible, setCompanyFormModalVisible] =
     useState<boolean>(false);
-  const { mutate } = useSWRConfig();
   const { data } = useCompanyList();
 
   const onSubmit: SubmitHandler<InputListType> = async data => {
@@ -42,14 +40,31 @@ export const FormComponent: React.FC<SignUpFormProps> = ({
 
     axiosClient
       .post('/auth/registration', reqData)
-      .then(function (response) {
+      .then(function (response: AxiosResponse) {
         toast.success('회원가입이 완료되었어요');
-        mutate(workerUrl.getAllWorker());
-        window.location.reload();
+        window.location.reload;
       })
-      .catch(function (error) {
+      .catch(function (error: AxiosError<{ message: string }>) {
         console.log(error);
-        toast.error('회원가입에 실패했어요');
+        if (error.response) {
+          switch (error.response.status) {
+            case 400:
+              toast.error(error.response.data.message);
+              break;
+            case 401:
+              toast.error(
+                '로그인 정보가 없어요\n새로고침 후 다시 한번 로그인 해주세요',
+              );
+              break;
+            case 403:
+              toast.error('이미 프로필이 등록되어있어요');
+              break;
+            default:
+              toast.error(
+                '알 수 없는 이유로 등록에 실패했어요\nhirecruit@gsm.hs.kr에 문의해주세요',
+              );
+          }
+        }
       });
   };
 

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -42,7 +42,7 @@ export const FormComponent: React.FC<SignUpFormProps> = ({
       .post('/auth/registration', reqData)
       .then(function (response: AxiosResponse) {
         toast.success('회원가입이 완료되었어요');
-        window.location.reload;
+        window.location.reload();
       })
       .catch(function (error: AxiosError<{ message: string }>) {
         console.log(error);


### PR DESCRIPTION
## 개요

사용자분들이 회원가입이나 회사 등록 기능에서 실패시 기존에는 '등록에 실패했어요' 라는 정보만 알려줘, ux적으로 좋지 않았다.
그래서 서버 에러 메세지 별로 상황에 맞게 유저들에게 솔루션을 제공하도록 하였다.

## 작업 내용

- company post logic 400, default 에러 핸들링 로직 추가
- profile post logic 400, 401, 403, default 에러 핸들링 로직 추가