### PR TITLE
Fix search input error

### DIFF
--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -14,16 +14,30 @@ export const SearchInputComponent: React.FC<SearchInputProps> = ({
   const router = useRouter();
   const inputEl = useRef<HTMLInputElement>(null);
 
+  const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchState(e.target.value);
+  };
+
+  const handleQueryString = (e: React.FocusEvent<HTMLInputElement>) => {
+    router.replace({
+      pathname: `/`,
+      query: { search: e.target.value },
+    });
+  };
+
   useEffect(() => {
-    // query string clean up
-    if (router.query.search === '') {
-      router.replace(`/`);
-    }
     if (router.query.search !== undefined && inputEl.current !== null) {
       inputEl.current.focus();
       inputEl.current.value = router.query.search as string;
 
       setSearchState(router.query.search as string);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (router.query.search === '') {
+      router.replace('/');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [router.query.search]);
@@ -37,12 +51,8 @@ export const SearchInputComponent: React.FC<SearchInputProps> = ({
       ref={inputEl}
       type="text"
       placeholder="이름 또는 회사로 검색"
-      onChange={e => {
-        router.replace({
-          pathname: `/`,
-          query: { search: e.target.value },
-        });
-      }}
+      onChange={handleSearch}
+      onBlur={handleQueryString}
     />
   );
 };

--- a/src/components/WorkerList/WorkerList.tsx
+++ b/src/components/WorkerList/WorkerList.tsx
@@ -21,7 +21,7 @@ export const WorkerListComponent: React.FC<WorkerListProps> = ({
 
   useEffect(() => {
     if (!initialWorkerList) return;
-    if (searchState === '') {
+    if (searchState === '' || searchState === undefined) {
       setWorkerList(initialWorkerList);
     } else {
       setWorkerList(
@@ -32,7 +32,7 @@ export const WorkerListComponent: React.FC<WorkerListProps> = ({
         ),
       );
     }
-  }, [workerList, searchState, initialWorkerList]);
+  }, [searchState, initialWorkerList]);
 
   return (
     <S.WorkerList


### PR DESCRIPTION
## 개요

검색 쿼리스트링 동기화 로직의 논리 오류로 인하여 검색시 사이트의 속도가 너무나도 떨어지게 되었다.

## 작업 내용

- `setWorkerList` 가 속한 useEffect의 deps에서 worker를 제거하였다.
- search state clear로직의 조건 부분을 변경하였다.
- router query가 적용되는 이벤트를 onBlur로 이동하였다.