### PR TITLE
Redesign/profile card

### DIFF
--- a/src/components/WorkerCard/WorkerCard.styles.tsx
+++ b/src/components/WorkerCard/WorkerCard.styles.tsx
@@ -4,9 +4,10 @@ import pallete from 'shared/Pallete';
 
 export const WorkerCard = styled.div`
   width: 100%;
-  border-radius: 0.5rem;
-  padding: 1.5rem;
+  border-radius: 0.625rem;
+  padding: 1.75rem;
   background: ${pallete.scheme.white};
+  box-shadow: 0px 4px 20px 0px #0000000f;
 `;
 
 export const ProfileWrapper = styled.div`
@@ -18,8 +19,7 @@ export const ProfileParagraph = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
-  gap: 0.313rem;
-  padding-left: 1.5rem;
+  padding-left: 1rem;
 `;
 
 export const NameBadgeWrapper = styled.div`
@@ -34,11 +34,15 @@ export const NameBadgeWrapper = styled.div`
 export const Name = styled.p`
   font-weight: 600;
   font-size: 1.125rem;
+  font-size: 1.25rem;
+  margin-bottom: 4px;
   color: ${pallete.scheme.black};
 `;
 
 export const Email = styled.a`
-  font-size: 0.85rem;
+  font-weight: 400;
+  font-size: 0.875rem;
+  margin-bottom: 11px;
   color: ${pallete.scheme.blue};
   text-decoration: none;
   &:hover {
@@ -47,17 +51,26 @@ export const Email = styled.a`
 `;
 
 export const Company = styled.p`
-  font-size: 0.8rem;
+  font-weight: 400;
+`;
+
+export const WorkerPosition = styled.span`
+  color: ${pallete.scheme.blue};
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.25;
+  padding-bottom: 4px;
 `;
 
 export const IntroduceCard = styled.div`
   width: 100%;
   height: auto;
-  padding: 0.75rem;
-  margin-top: 1.25rem;
+  padding: 0.875rem;
+  margin-top: 1rem;
   background-color: ${pallete.scheme.gray};
   border-radius: 0.5rem;
   p {
+    margin-top: 4px;
     color: ${pallete.scheme.paragraph};
     font-size: 0.875rem;
     font-weight: 500;
@@ -69,10 +82,6 @@ export const WorkerButtonWrapper = styled.div`
   width: 100%;
   display: flex;
   justify-content: center;
-  margin-top: 1.25rem;
+  margin-top: 1rem;
   gap: 0.8rem;
-`;
-
-export const WorkerPosition = styled.span`
-  color: ${pallete.scheme.blue};
 `;

--- a/src/components/WorkerCard/WorkerCard.tsx
+++ b/src/components/WorkerCard/WorkerCard.tsx
@@ -6,7 +6,7 @@ import { Button } from 'components/common/Button';
 import { WorkerProfileImage } from 'components/common/WorkerProfileImage';
 import { Tooltip } from 'components/common/Tooltip';
 
-import * as S from './Worker.styles';
+import * as S from './WorkerCard.styles';
 import { CheckBadge } from 'assets/icons/CheckBadge';
 
 interface WorkerCardProps {
@@ -80,11 +80,8 @@ export const WorkerCardComponent: React.FC<WorkerCardProps> = ({
       </S.ProfileWrapper>
       {!!introduction && (
         <S.IntroduceCard>
-          <p>
-            <S.WorkerPosition>{`${devYear}년차 ${position}`}</S.WorkerPosition>
-            <br />
-            {introduction}
-          </p>
+          <S.WorkerPosition>{`${devYear}년차 ${position}`}</S.WorkerPosition>
+          <p>{introduction}</p>
         </S.IntroduceCard>
       )}
       <S.WorkerButtonWrapper>

--- a/src/components/common/Button/Button.styles.tsx
+++ b/src/components/common/Button/Button.styles.tsx
@@ -5,7 +5,7 @@ import pallete from 'shared/Pallete';
 export const Button = styled.button`
   border: none;
   width: 100%;
-  height: 2.275rem;
+  height: 2.5rem;
   text-align: center;
   font-weight: 700;
   font-size: 0.9rem;

--- a/src/components/common/WorkerProfileImage/workerProfileImage.styles.tsx
+++ b/src/components/common/WorkerProfileImage/workerProfileImage.styles.tsx
@@ -5,7 +5,11 @@ import pallete from 'shared/Pallete';
 export const WorkerProfileImage = styled.div`
   width: 4.25rem;
   height: 4.25rem;
-  border-radius: 33%;
+  border-radius: 0.5rem;
   overflow: hidden;
   background-color: ${pallete.scheme.gray};
+  &:hover {
+    opacity: 0.9;
+    transition: opacity 0.2s;
+  }
 `;

--- a/src/shared/Pallete.ts
+++ b/src/shared/Pallete.ts
@@ -16,7 +16,7 @@ const pallete: Readonly<ColorTheme> = {
   scheme: {
     white: '#ffffff',
     black: '#000000',
-    gray: '#f4f4f4',
+    gray: '#fafafa',
     darkgray: '#888888',
     blue: '#3d9cf7',
     red: '#F31260',


### PR DESCRIPTION
## 작업 내용

- 버튼 height값을 변경하였습니다.
- 프로필 이미지 컴포넌트 스타일을 변경하고, opacity값을 주어 사용자 경험을 더 나은 이상향의 아발론으로
- gray 값이 기존 `#f4f4f4` 에서 `#fafafa`로 변경되었습니다.
- 프로필 카드의 여러 박스모델값들을 변경하였습니다.