### PR TITLE
Add /device/mobile matcher

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -23,5 +23,5 @@ export async function middleware(req: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/'],
+  matcher: ['/', '/device/mobile'],
 };


### PR DESCRIPTION
## 작업 내용

모바일로 들어가는 경우 site-state 액션이 적용되지 않는 이슈를 확인, `/device/mobile` path를 middleware matcher에 추가했습니다.